### PR TITLE
Removed transaction management after commit.

### DIFF
--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -146,4 +146,3 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
             del values, pks
 
             connection.cursor().execute(sql, parameters)
-            transaction.commit_unless_managed(using=using)


### PR DESCRIPTION
This was placed here to support older versions of Django.
Due to Django's transaction model overhaul in v1.8 this is
no longer needed.
